### PR TITLE
update read_compdct.ado

### DIFF
--- a/read_compdct.ado
+++ b/read_compdct.ado
@@ -35,7 +35,7 @@ end
 program read_compdct
 syntax, compdct(string) dict_name(string) [out(string)]
 
-use `compdct', clear
+use "`compdct'", clear
 
 qui keep if dct == "`dict_name'"
 * mantém só as linhas referentes ao dct desejado


### PR DESCRIPTION
inclusão de aspas em _use `compdct'_ na linha 38. Modificação necessária para que o código funcione em repositórios que apresentem espaçamento.