### PR TITLE
Código para encontrar erros nos dcts

### DIFF
--- a/erros_dcts.do
+++ b/erros_dcts.do
@@ -1,0 +1,7 @@
+/* Código para encontrar erros nos dcts. */
+
+local dct "caminho/até/o/.dct"
+local arquivo "caminho/até/.txt"
+infile using "`dct'", using("`arquivo'") clear
+
+/* onde .txt é o input disponibilizado pelo IBGE */


### PR DESCRIPTION
Código para encontrar erros nos dicionários. O output são as linhas do dct que diferem do input disponibilizado pelo IBGE.