### PR TITLE
Adding 2023 to the dialogue box

### DIFF
--- a/PNAD_Continua/Trimestral/datazoom_pnadcontinua.dlg
+++ b/PNAD_Continua/Trimestral/datazoom_pnadcontinua.dlg
@@ -7,7 +7,7 @@ POSITION . . 350 350
 DIALOG main, label("PNAD Contínua") tabtitle("Main")
 BEGIN
 ******************************************************************************   
-GROUPBOX caixaAnos 20 20 100 300, label("Ano(s)")
+GROUPBOX caixaAnos 20 10 100 320, label("Ano(s)")
 
    CHECKBOX    ck2012 +14 +24 120  ., label("2012")  option(2012)
    CHECKBOX    ck2013 @ +24 120    ., label("2013")  option(2013)
@@ -20,13 +20,14 @@ GROUPBOX caixaAnos 20 20 100 300, label("Ano(s)")
    CHECKBOX	   ck2020 @ +24 120	   ., label("2020")  option(2020)
    CHECKBOX	   ck2021 @ +24 120	   ., label("2021")  option(2021)
    CHECKBOX	   ck2022 @ +24 120	   ., label("2022")  option(2022)
+   CHECKBOX	   ck2023 @ +24 120	   ., label("2023")  option(2023)
 
-GROUPBOX caixaDicionários 160 20 140 118, label("Bases de Dados")
+GROUPBOX caixaDicionários 160 10 140 118, label("Bases de Dados")
 
 	BUTTON	fldados 	+20 +35 100 ., label("Dados originais...") onpush(script dados) 
 	BUTTON	flsalvando  @ +35 100 ., label("Salvando...") onpush(script salvando) 
 
-GROUPBOX caixaid 160 150 140 116, label("Identificação do Indivíduo")
+GROUPBOX caixaid 160 140 160 116, label("Identificação do Indivíduo")
 
 	RADIO	nid     +10 +30 150 ., first label("Sem identificação") option(nid)
 	RADIO	idbas	+0 +22 150 ., middle label("Básica") option(idbas)
@@ -76,7 +77,7 @@ PROGRAM command
 		beginoptions
 			/*Parte da syntax: anos a extrair*/
 			put "years("
-			option main.ck2012 main.ck2013 main.ck2014 main.ck2015 main.ck2016 main.ck2017 main.ck2018 main.ck2019 main.ck2020 main.ck2021 main.ck2022
+			option main.ck2012 main.ck2013 main.ck2014 main.ck2015 main.ck2016 main.ck2017 main.ck2018 main.ck2019 main.ck2020 main.ck2021 main.ck2022 main.ck2023
 			put ") "
 			/*Parte da syntax: base de dados originais*/
 			put saidadata " "

--- a/PNAD_Continua/Trimestral/datazoom_pnadcontinua_en.dlg
+++ b/PNAD_Continua/Trimestral/datazoom_pnadcontinua_en.dlg
@@ -7,7 +7,7 @@ POSITION . . 350 350
 DIALOG main, label("PNAD Contínua") tabtitle("Main")
 BEGIN
 ******************************************************************************   
-GROUPBOX caixaAnos 20 20 100 300, label("Year(s)")
+GROUPBOX caixaAnos 20 10 100 320, label("Year(s)")
 
    CHECKBOX    ck2012 +14 +24 120  ., label("2012")  option(2012)
    CHECKBOX    ck2013 @ +24 120    ., label("2013")  option(2013)
@@ -19,14 +19,15 @@ GROUPBOX caixaAnos 20 20 100 300, label("Year(s)")
    CHECKBOX	   ck2019 @ +24 120	   ., label("2019")  option(2019)
    CHECKBOX	   ck2020 @ +24 120	   ., label("2020")  option(2020)
    CHECKBOX	   ck2021 @ +24 120	   ., label("2021")  option(2021)
-   CHECKBOX	   ck2022 @ +24 120	   ., label("2022")  option(2022)
-   
-GROUPBOX caixaDicionários 160 20 140 118, label("Databases")
+   CHECKBOX	   ck2022 @ +24 120	   ., label("2022")  option(2022) 
+   CHECKBOX	   ck2023 @ +24 120	   ., label("2023")  option(2023)
+
+GROUPBOX caixaDicionários 160 10 140 118, label("Databases")
 
 	BUTTON	fldados 	+20 +35 100 ., label("Original Files...") onpush(script dados) 
 	BUTTON	flsalvando  @ +35 100 ., label("Saving...") onpush(script salvando) 
 
-GROUPBOX caixaid 160 150 140 116, label("Individual Identification")
+GROUPBOX caixaid 160 140 160 116, label("Individual Identification")
 
 	RADIO	nid     +10 +30 150 ., first label("No Identification") option(nid)
 	RADIO	idbas	+0 +22 150 ., middle label("Basic") option(idbas)
@@ -76,7 +77,7 @@ PROGRAM command
 		beginoptions
 			/*Parte da syntax: anos a extrair*/
 			put "years("
-			option main.ck2012 main.ck2013 main.ck2014 main.ck2015 main.ck2016 main.ck2017 main.ck2018 main.ck2019 main.ck2020 main.ck2021 main.ck2022
+			option main.ck2012 main.ck2013 main.ck2014 main.ck2015 main.ck2016 main.ck2017 main.ck2018 main.ck2019 main.ck2020 main.ck2021 main.ck2022 main.ck2023
 			put ") "
 			/*Parte da syntax: base de dados originais*/
 			put saidadata " "

--- a/datazoom_social.dlg
+++ b/datazoom_social.dlg
@@ -24,7 +24,7 @@ BEGIN
 	TEXTBOX txb_pme    	 	+158 @ @ @, label("Pesquisa Mensal de Emprego - 1990 a 2015") center
 	TEXTBOX txb_pnad     		+158 @ @ @, label("PNAD Antiga - 2001 a 2015") center
 	
-    	TEXTBOX txb_pncon			10 175 140 ., label("PNAD Contínua - 2012 a 2022") center
+    	TEXTBOX txb_pncon			10 175 140 ., label("PNAD Contínua - 2012 a 2023") center
 	TEXTBOX txb_pncov			+158 @ @ @, label("PNAD Covid - 2020") center
 	TEXTBOX txb_pns   			+158 @ @ @, label("Pesquisa Nacional de Saúde - 2013 e 2019") center
 	TEXTBOX txb_pof 			+158 @ @ @, label("Pesquisa de Orçamentos Familiares - 1995 a 2018") center

--- a/datazoom_social_en.dlg
+++ b/datazoom_social_en.dlg
@@ -24,7 +24,7 @@ BEGIN
 	TEXTBOX txb_pme    	 	+158 @ @ @, label("Monthly Employment Survey - 1990 to 2015") center
 	TEXTBOX txb_pnad     		+158 @ @ @, label("National Household Sample Survey - 2001 to 2015") center
 	
-    	TEXTBOX txb_pncon			10 175 140 ., label("Continuous PNAD - 2012 to 2022") center
+    	TEXTBOX txb_pncon			10 175 140 ., label("Continuous PNAD - 2012 to 2023") center
 	TEXTBOX txb_pncov			+158 @ @ @, label("PNAD Covid - 2020") center
 	TEXTBOX txb_pns   			+158 @ @ @, label("National Survey of Health - 2013 and 2019") center
 	TEXTBOX txb_pof 			+158 @ @ @, label("Consumer Expenditure Survey - 1995 to 2018") center


### PR DESCRIPTION
I added the 2023 option to the dialogue box and made some changes in the position and height of the "years" box, so it looked better to the user. I also changed the position of the "id" and "dictionary" boxes to make them symetric to "years" and increased the width of the first one, because the portuguese title was overwriting the right column.