### PR TITLE
Solve issue #81

### DIFF
--- a/POF/2017/datazoom_pof2017.ado
+++ b/POF/2017/datazoom_pof2017.ado
@@ -816,7 +816,7 @@ if "`tr'" == "tr5"{ // Aluguel Estimado
 if "`tr'" == "tr2"{ // Despesa Coletiva
 	replace valor_anual_def = V8000_DEFLA * V9011 * FATOR_ANUALIZACAO /*
 					*/ if QUADRO == 10 | QUADRO == 19
-	replace valor_anual_def = V8000_DEFLA * V9011 * FATOR_ANUALIZACAO /*
+	replace valor_anual_def = V8000_DEFLA * FATOR_ANUALIZACAO /*
 					*/ if QUADRO != 10 & QUADRO != 19
 	gen inss_anual = V1904_DEFLA * V9011 * FATOR_ANUALIZACAO				
 }


### PR DESCRIPTION
V9011 refers to the number of months the individual purchased the item in a year. It is therefore used in the expenses' annaulziation. However it is only applicable to "quadros" 10 and 19. Line 819 used it where it shouldn't be used.