### PR TITLE
Adição da compatibilização do novo trimestre (2025) da Pnadc no Stata

### DIFF
--- a/PNAD_Continua/Trimestral/datazoom_pnadcontinua.dlg
+++ b/PNAD_Continua/Trimestral/datazoom_pnadcontinua.dlg
@@ -2,12 +2,12 @@
 VERSION 10.0
 SYNCHRONOUS_ONLY
 
-POSITION . . 350 380
+POSITION . . 340 320
 
 DIALOG main, label("PNAD Contínua") tabtitle("Main")
 BEGIN
 ******************************************************************************   
-GROUPBOX caixaAnos 20 10 100 340, label("Ano(s)")
+GROUPBOX caixaAnos 20 10 130 200, label("Ano(s)")
 
    CHECKBOX    ck2012 +14 +24 120  ., label("2012")  option(2012)
    CHECKBOX    ck2013 @ +24 120    ., label("2013")  option(2013)
@@ -16,13 +16,14 @@ GROUPBOX caixaAnos 20 10 100 340, label("Ano(s)")
    CHECKBOX	   ck2016 @ +24 120	   ., label("2016")  option(2016)
    CHECKBOX	   ck2017 @ +24 120	   ., label("2017")  option(2017)
    CHECKBOX	   ck2018 @ +24 120	   ., label("2018")  option(2018)
-   CHECKBOX	   ck2019 @ +24 120	   ., label("2019")  option(2019)
+   CHECKBOX	   ck2019 +60 -144 120	   ., label("2019")  option(2019)
    CHECKBOX	   ck2020 @ +24 120	   ., label("2020")  option(2020)
    CHECKBOX	   ck2021 @ +24 120	   ., label("2021")  option(2021)
    CHECKBOX	   ck2022 @ +24 120	   ., label("2022")  option(2022)
    CHECKBOX	   ck2023 @ +24 120	   ., label("2023")  option(2023)
-   CHECKBOX   ck2024 @ +24 120	   ., label("2024")  option(2024)
-
+   CHECKBOX    ck2024 @ +24 120	   ., label("2024")  option(2024)
+   CHECKBOX    ck2025 @ +24 120	   ., label("2025")  option(2025)
+   
 GROUPBOX caixaDicionários 160 10 140 118, label("Bases de Dados")
 
 	BUTTON	fldados 	+20 +35 100 ., label("Dados originais...") onpush(script dados) 
@@ -34,9 +35,9 @@ GROUPBOX caixaid 160 140 160 116, label("Identificação do Indivíduo")
 	RADIO	idbas	+0 +22 150 ., middle label("Básica") option(idbas)
 	RADIO	idrs	+0 +22 150 ., last label("Avançada") option(idrs)
 
-	CHECKBOX	eng     170  280 200 24, label("Labels em inglês") option(english)
+	CHECKBOX	eng     170  270 200 24, label("Labels em inglês") option(english)
 
-TEXT     credit     0   350 340  ., label("PUC-Rio - Departamento de Economia") right
+TEXT     credit     0   300 300  ., label("PUC-Rio - Departamento de Economia") right
 
 END
 
@@ -78,7 +79,7 @@ PROGRAM command
 		beginoptions
 			/*Parte da syntax: anos a extrair*/
 			put "years("
-			option main.ck2012 main.ck2013 main.ck2014 main.ck2015 main.ck2016 main.ck2017 main.ck2018 main.ck2019 main.ck2020 main.ck2021 main.ck2022 main.ck2023 main.ck2024
+			option main.ck2012 main.ck2013 main.ck2014 main.ck2015 main.ck2016 main.ck2017 main.ck2018 main.ck2019 main.ck2020 main.ck2021 main.ck2022 main.ck2023 main.ck2024 main.ck2025
 			put ") "
 			/*Parte da syntax: base de dados originais*/
 			put saidadata " "

--- a/PNAD_Continua/Trimestral/datazoom_pnadcontinua_en.dlg
+++ b/PNAD_Continua/Trimestral/datazoom_pnadcontinua_en.dlg
@@ -2,12 +2,12 @@
 VERSION 10.0
 SYNCHRONOUS_ONLY
 
-POSITION . . 350 380
+POSITION . . 340 320
 
 DIALOG main, label("PNAD Contínua") tabtitle("Main")
 BEGIN
 ******************************************************************************   
-GROUPBOX caixaAnos 20 10 100 340, label("Year(s)")
+GROUPBOX caixaAnos 20 10 130 200, label("Year(s)")
 
    CHECKBOX    ck2012 +14 +24 120  ., label("2012")  option(2012)
    CHECKBOX    ck2013 @ +24 120    ., label("2013")  option(2013)
@@ -16,13 +16,14 @@ GROUPBOX caixaAnos 20 10 100 340, label("Year(s)")
    CHECKBOX	   ck2016 @ +24 120	   ., label("2016")  option(2016)
    CHECKBOX	   ck2017 @ +24 120	   ., label("2017")  option(2017)
    CHECKBOX	   ck2018 @ +24 120	   ., label("2018")  option(2018)
-   CHECKBOX	   ck2019 @ +24 120	   ., label("2019")  option(2019)
+   CHECKBOX	   ck2019 +60 -144 120	   ., label("2019")  option(2019)
    CHECKBOX	   ck2020 @ +24 120	   ., label("2020")  option(2020)
    CHECKBOX	   ck2021 @ +24 120	   ., label("2021")  option(2021)
    CHECKBOX	   ck2022 @ +24 120	   ., label("2022")  option(2022) 
    CHECKBOX	   ck2023 @ +24 120	   ., label("2023")  option(2023)
    CHECKBOX	   ck2024 @ +24 120	   ., label("2024")  option(2024)
-
+   CHECKBOX	   ck2025 @ +24 120	   ., label("2025")  option(2025)
+   
 GROUPBOX caixaDicionários 160 10 140 118, label("Databases")
 
 	BUTTON	fldados 	+20 +35 100 ., label("Original files...") onpush(script dados) 
@@ -34,9 +35,9 @@ GROUPBOX caixaid 160 140 160 116, label("Individual Identification")
 	RADIO	idbas	+0 +22 150 ., middle label("Basic") option(idbas)
 	RADIO	idrs	+0 +22 150 ., last label("Advanced") option(idrs)
 
-	CHECKBOX	eng     170  280 200 24, label("Labels in English") option(english)
+	CHECKBOX	eng     170  270 200 24, label("Labels in English") option(english)
 	
-TEXT     credit     0   350 340    ., label("PUC-Rio - Department of Economics") right
+TEXT     credit     0   300 300    ., label("PUC-Rio - Department of Economics") right
 
 END
 
@@ -78,7 +79,7 @@ PROGRAM command
 		beginoptions
 			/*Parte da syntax: anos a extrair*/
 			put "years("
-			option main.ck2012 main.ck2013 main.ck2014 main.ck2015 main.ck2016 main.ck2017 main.ck2018 main.ck2019 main.ck2020 main.ck2021 main.ck2022 main.ck2023 main.ck2024
+			option main.ck2012 main.ck2013 main.ck2014 main.ck2015 main.ck2016 main.ck2017 main.ck2018 main.ck2019 main.ck2020 main.ck2021 main.ck2022 main.ck2023 main.ck2024 main.ck2025
 			put ") "
 			/*Parte da syntax: base de dados originais*/
 			put saidadata " "

--- a/datazoom_social.dlg
+++ b/datazoom_social.dlg
@@ -24,7 +24,7 @@ BEGIN
 	TEXTBOX txb_pme    	 	+158 @ @ @, label("Pesquisa Mensal de Emprego - 1990 a 2015") center
 	TEXTBOX txb_pnad     		+158 @ @ @, label("PNAD Antiga - 2001 a 2015") center
 	
-    	TEXTBOX txb_pncon			15 175 140 40, label("PNAD Contínua - 2012 a 2023") center
+    	TEXTBOX txb_pncon			15 175 140 40, label("PNAD Contínua - 2012 a 2025") center
 	TEXTBOX txb_pncov			+158 @ @ @, label("PNAD Covid - 2020") center
 	TEXTBOX txb_pns   			+158 @ @ @, label("Pesquisa Nacional de Saúde - 2013 e 2019") center
 	TEXTBOX txb_pof 			+158 @ @ @, label("Pesquisa de Orçamentos Familiares - 1995 a 2018") center

--- a/datazoom_social_en.dlg
+++ b/datazoom_social_en.dlg
@@ -24,7 +24,7 @@ BEGIN
 	TEXTBOX txb_pme    	 	+158 @ @ @, label("Monthly Employment Survey - 1990 to 2015") center
 	TEXTBOX txb_pnad     		+158 @ @ @, label("National Household Sample Survey - 2001 to 2015") center
 	
-    	TEXTBOX txb_pncon			15 180 140 40, label("Continuous PNAD - 2012 to 2023") center
+    	TEXTBOX txb_pncon			15 180 140 40, label("Continuous PNAD - 2012 to 2025") center
 	TEXTBOX txb_pncov			+158 @ @ @, label("PNAD Covid - 2020") center
 	TEXTBOX txb_pns   			+158 @ @ @, label("National Survey of Health - 2013 and 2019") center
 	TEXTBOX txb_pof 			+158 @ @ @, label("Consumer Expenditure Survey - 1995 to 2018") center


### PR DESCRIPTION
Foi adicionado o trimestre 1 (2025) da Pnadc trimestral ao Pacote do Data Zoom Social Stata, Já testei, tanto em português quanto em inglês. Dessa forma alterei a caixa de diálogo para adequar essa nova adição, para o mesmo padrão da pnadc anual, ambas as caixas foram atualizadas (português e inglês), assim como foi atualizado as datas das pesquisas na caixa de diálogo principal, para mostrar que o nosso pacote possui compatibilização com as pesquisas mais recentes.  

Close #145 