### PR TITLE
Revert "Uptade link to PNAD Contínua Supplements Guide"

### DIFF
--- a/PNAD_Continua/Anual/datazoom_pnadcont_anual.dlg
+++ b/PNAD_Continua/Anual/datazoom_pnadcont_anual.dlg
@@ -103,7 +103,7 @@ BEGIN
 
 PROGRAM hlink1
 	BEGIN
-		put "datazoom_link_guia_suplementos"
+		put "datazoom_link"
 		stata
    END
 

--- a/PNAD_Continua/Anual/datazoom_pnadcont_anual_en.dlg
+++ b/PNAD_Continua/Anual/datazoom_pnadcont_anual_en.dlg
@@ -104,7 +104,7 @@ BEGIN
 
 PROGRAM hlink1
 	BEGIN
-		put "datazoom_link_guia_suplementos"
+		put "datazoom_link"
 		stata
    END
 

--- a/datazoom_link.ado
+++ b/datazoom_link.ado
@@ -1,0 +1,8 @@
+******************************************************
+*                   datazoom_link.ado                  *
+******************************************************
+* version 1.0
+
+program define datazoom_link
+	di `"{browse "https://drive.google.com/file/d/1bP8HtXvHi56qgSXyH-jyvD8HoVURHvZX/view?usp=drive_link"}"'
+end

--- a/datazoom_link_guia_suplementos.ado
+++ b/datazoom_link_guia_suplementos.ado
@@ -1,8 +1,0 @@
-******************************************************
-*                   datazoom_link_guia_suplementos.ado                  *
-******************************************************
-* version 1.0
-
-program define datazoom_link_guia_suplementos
-	di `"{browse "https://drive.google.com/file/d/12BgRZzY3uaSi08NY_Z93JU4jlCJa_9wI/view?usp=drive_link"}"'
-end


### PR DESCRIPTION
Apparently, a file that had its name changed was important to install correctly datazoom_social from github.

Reverting these changes might fix the problem.

Reverts datazoompuc/datazoom_social_Stata#163