### PR TITLE
Add missing closing details tag in documentation

### DIFF
--- a/README_en.md
+++ b/README_en.md
@@ -203,7 +203,9 @@ In Portuguese:
   dictionary](https://raw.githubusercontent.com/datazoompuc/datazoom_social_stata/master/docs/ECINF/dicionario_1997.doc)
 - [ECINF 2003
   dictionary](https://raw.githubusercontent.com/datazoompuc/datazoom_social_stata/master/docs/ECINF/dicionario_2003.xls)
+
 </details>
+
 ## PME
 
 PME, the Brazilian Monthly Employment Survey, is a sample survey

--- a/vignettes/en/ecinf.Rmd
+++ b/vignettes/en/ecinf.Rmd
@@ -32,3 +32,5 @@ Due to the large number of topics investigated, there are several microdata file
 
   - [ECINF 1997 dictionary](https://raw.githubusercontent.com/datazoompuc/datazoom_social_stata/master/docs/ECINF/dicionario_1997.doc)
   - [ECINF 2003 dictionary](https://raw.githubusercontent.com/datazoompuc/datazoom_social_stata/master/docs/ECINF/dicionario_2003.xls)
+
+</details>


### PR DESCRIPTION
Inserted closing </details> tag in ecinf.Rmd to properly format collapsible sections and correct document structure, generating a new README_en.md.

Before that, a lot of information in Readme was incorrectly hidden.

This change is correcting the same issue of the last pull request, but now via .rmd, in accordance with good programming practices.