### PR TITLE
corrige help e dialog box da pnadc anual

### DIFF
--- a/PNAD_Continua/Anual/datazoom_pnadcont_anual.sthlp
+++ b/PNAD_Continua/Anual/datazoom_pnadcont_anual.sthlp
@@ -29,10 +29,10 @@
 {synopthdr}
 {synoptline}
 {syntab:Input}
-{synopt:{opt years(numlist)}} anos da PNAD Contínua Anual {p_end}
+{synopt:{opt years(numlist)}} anos seguidos por visitas ou trimestres da PNAD Contínua Anual {p_end}
 {synopt:{opt original(str)}} caminho da pasta onde se localizam os arquivos de dados originais {p_end}
 {synopt:{opt saving(str)}} caminho da pasta onde serão salvas as novas bases de dados {p_end}
-{synopt:{opt english}} labels das variáveis em inglês {p_end}
+{synopt:{opt english}} define que labels das variáveis sejam apresentados em inglês {p_end}
 {synoptline}
 {p2colreset}{...}
 {p 4 6 2}
@@ -44,46 +44,52 @@ Digite {cmd:db datazoom_pnadcont_anual} para utilizar a função via caixa de di
 
 {p 4 4 2}
 {cmd:datazoom_pnadcont_anual} extrai e constrói bases de dados da PNAD Contínua Anual em formato Stata a partir
-dos microdados originais do IBGE, para os anos de 2012 a 2019. 
+dos microdados originais do IBGE, para os anos de 2012 a 2024.
 
 {p 4 4 2}
-Apesar da periodicidade de divulgação da pesquisa ser anual, este programa permite, a partir de 2016, a escolha de duas entrevistas específicas para extração: (2016_entr1 e 2017_entr1)
-referentes à 1ªentrevista do domicílio e (2016_entr5 e 2017_entr5) referentes à 5ª entrevista do domicílio. Isso se deve à mudança na pesquisa do IBGE
-com a transferência da investigação "Outras formas de trabalho" para a 5ª entrevista do domicílio nos anos de 2016 e 2017. Para cada entrevista, 
-há uma base original em txt disponível no site do IBGE. Para maiores informações sobre a mudança da entrevista, olhar nota técnica da pesquisa no site do IBGE.
+Este programa permite, para cada ano, a escolha de entrevistas (visitas) e trimestres específicos para extração. Ex: years(2016_vis1 2017_tri2) são
+referentes às 1ªentrevistas (acumuladas) do domicílio em 2016 e ao 2°trimestre de 2017. Os dados da PNAD Contínua Anual são especialmente úteis para analisar
+os suplementos da PNAD Contínua, em que o IBGE faz perguntas adicionais de temas específicos em trimestres e visitas específicas em determinados anos.
+Para ver em quais períodos estão cada suplemento, consulte o Guia de Suplementos. Você pode gerar um link de download usando nossa dialog box,
+ou pode pesquisar diretamente no site do IBGE.
+Para maiores informações sobre os dados de visitas acumuladas, trimestres e suplementos, olhar nota técnica da pesquisa no site do IBGE.
+Para cada visita e cada trimestre, há uma base original em txt disponível no site do IBGE. Faça o download dos dados originais e coloque o caminho dessa pasta como parâmetro de "original" para usar corretamente a função.
+
 
 {p 4 4 2}
 Como a pesquisa ainda é publicada pelo IBGE, este programa está em constante atualização.
   
 {p 4 4 2}
-O programa gera uma base para cada ano selecionado. Se for o caso, utilize o 
-comando {help append} para empilhar as bases.
+O programa gera uma base para cada período (ano_visita e/ou ano_trimestre) selecionado. Pode ser útil utilizar o comando {help append} para empilhar as bases, caso sejam compatíveis.
 
 {marker options}{...}
 {title:Options}
 {dlgtab:Input}
 
 {phang} 
-{opt years(numlist)} especifica a lista de anos com os quais o usuário deseja trabalhar. Este programa 
-pode ser utilizado para o período de 2012 a 2019. 
+{opt years(numlist)} especifica a lista de anos, com suas visitas e/ou trimestres com os quais o usuário deseja trabalhar. Este programa 
+pode ser utilizado para o período de 2012 a 2024, com visitas e trimestres específicos. Não há arquivos de microdados na disseminação anual para todo trimestre ou visita.
+Portanto, é necessário verificar quais trimestres e visitas estão disponível para chamar corretamente a função.
 
 {phang} {opt original(str)} indica o caminho da pasta onde estão localizados os arquivos de dados originais. 
-Existe um arquivo de microdados para cada ano da pesquisa, exceto para 2016 e 2017, nos quais há dois microdados por ano (um microdado referente à 1ª 
-entrevista e outro referente à 5ª entrevista). Todos eles devem estar posicionados na mesma pasta para que o programa funcione adequadamente.
+Existem arquivos de microdados para cada ano da pesquisa, podendo haver um ou mais por ano, referentes às visitas acumuladas e aos trimestres. 
+Todos eles devem estar na mesma pasta para que o programa funcione adequadamente.
 O Portal não disponibiliza os dados originais, que podem ser obtidos no site do IBGE.
 
 {phang} {opt saving(str)} indica o caminho da pasta onde devem ser salvas as bases de dados produzidas pelo programa.
+
+{phang} {opt english} especifica que os rótulos das variáveis sejam apresentados em inglês. O padrão é português (Brasil).
 
 {marker examples}{...}
 {title:Examples}
 
 {p 4 4 2}
-Bases de dados anuais 
+Bases de dados anuais
 
-{p 8 6 2}. datazoom_pnadcont_anual, years(2012 2014 2015) original("~/mydir") saving("~/mydir") 
+{p 8 6 2}. datazoom_pnadcont_anual, years(2012_vis1 2014_vis1 2024_tri4) original("~/mydir") saving("~/mydir") 
 
 {p 6 6 2}
-Três bases de dados são geradas, uma para cada ano selecionado.
+Três bases de dados são geradas, uma para cada visita e trimestre selecionado.
 
 {title:Author}
 

--- a/PNAD_Continua/Anual/datazoom_pnadcont_anual_en.sthlp
+++ b/PNAD_Continua/Anual/datazoom_pnadcont_anual_en.sthlp
@@ -29,10 +29,10 @@
 {synopthdr}
 {synoptline}
 {syntab:Input}
-{synopt:{opt years(numlist)}}  {p_end}
+{synopt:{opt years(numlist)}} years followed by visits or trimesters (quarters) {p_end}
 {synopt:{opt original(str)}} path to original microdata {p_end}
 {synopt:{opt saving(str)}} path where databases will be saved {p_end}
-{synopt:{opt english}} variable labels in English {p_end}
+{synopt:{opt english}} requests variable labels in English {p_end}
 {synoptline}
 {p2colreset}{...}
 {p 4 6 2}
@@ -44,35 +44,30 @@ Use command {cmd:db datazoom_pnadcont_anual_en} to access through dialog box.
 
 {p 4 4 2}
 {cmd:datazoom_pnadcont_anual} extracts and builds databases from the original PNAD Contínua 
-Annual Dissemination microdata, for years 2012 to 2019. 
+Annual Dissemination microdata, for years 2012 to 2024. 
 
 {p 4 4 2}
-Although Annual Continuous PNAD is an annual survey, from 2016 this program allows selection for the first interview of the household (2016_entr1 and 2017_entr1 ) and 
-for the 5th interview of the household (2016_entr5 and 2017_entr5). This is due to the change in IBGE's survey with the transfer of the questions  "Other forms of work"
- to the 5th home interview in the years 2016 and 2019. For each interview, there is an original txt database available on the IBGE website. 
- For more information about the survey's change, read the technical note of the survey on the IBGE website.
+This program allows, for each year, the selection of the available household acumulated visits and quarters for data extraction. For example, years(2016_vis1 2017_tri2) refers to the first cumulative household visits in 2016 and to the second quarter (trimester) of 2017. Annual Continuous PNAD data are particularly useful for the analysis of PNAD supplements, in which IBGE includes additional questions on specific topics in particular quarters and household visits in selected years. To verify the periods in which each supplement is available, consult the Supplements Guide. Users may generate a download link using the program’s dialog box, or alternatively search directly on the IBGE website. For further information on cumulative visits data, quarters, and supplements, read the survey’s technical note available on the IBGE website. For each household visit and each quarter, there is an original txt database available on the IBGE website. Users must download the original data files and provide the path to this folder in the option original() in order to use the command correctly.
  
 {p 4 4 2}
 Since IBGE still conducts Annual PNAD Continuous surveys, this program will be continuously updated.
   
 {p 4 4 2}
-The program generates a database for each selected year. If necessary, use
-command {help append} in order to aggregate all years.
+The program generates one dataset for each selected period (year_visit and/or year_quarter). It may be useful to use the {help append} command to stack the datasets, provided that they are compatible.
 
 {marker options}{...}
 {title:Options}
 {dlgtab:Input}
 
 {phang} 
-{opt years(numlist)} specifies the list of years the user wants to work with. This program
-covers all years from 2012 to 2019.
+{opt years(numlist)} Specifies the list of years, together with the household visits and/or quarters with which the user wishes to work. This program can be used for the period from 2012 to 2024, with specific visits and quarters. Annual dissemination microdata files are not available for all visits or quarters. Therefore, it is necessary to verify which visits and quarters are available in order to call the command correctly.
 
-{phang} {opt original(str)} indicates the path of the original data files. 
-There is one data file for each annual survey, except for 2016 and 2017, when there are two annual surveys per year 
-(one referring to the first interview and another referring to the fifth interview). All of these files must be placed in the same 
-folder for the program's proper functioning.
+{phang} {opt original(str)} Indicates the path to the folder where the original data files are located. There are microdata files for each survey year, and there may be one or more files per year, referring to cumulative household visits and quarters. All files must be stored in the same folder in order for the program to work properly. 
+The Portal does not provide the original data files, which can be obtained from the IBGE website.
 
 {phang} {opt saving(str)} specifies the folder path where the new databases are to be saved.
+
+{phang} {opt english} requests English variable labels. By default, labels are provided in Portuguese (Brazil).
 
 {marker examples}{...}
 {title:Examples}
@@ -80,10 +75,10 @@ folder for the program's proper functioning.
 {p 4 4 2}
 Annual databases, with English variable labels
 
-{p 8 6 2}. datazoom_pnadcont_anual, years(2012 2014 2015) original("~/mydir") saving("~/mydir") english 
+{p 8 6 2}. datazoom_pnadcont_anual, years(2012_vis1 2014_vis1 2017_tri2) original("~/mydir") saving("~/mydir") english 
 
 {p 6 6 2}
-Three databases are created, one per year.
+Three databases are created, one per visit or quarter.
 
 {title:Author}
 

--- a/datazoom_link.ado
+++ b/datazoom_link.ado
@@ -6,7 +6,3 @@
 program define datazoom_link
 	di `"{browse "https://raw.githubusercontent.com/datazoompuc/datazoom_social_Stata/main/docs/pt/PNAD%20Continua/PNADC_Pesquisas_Suplementares_Anuais_20251119.pdf"}"'
 end
-
-program define datazoom_link_en
-	di `"{browse "https://raw.githubusercontent.com/datazoompuc/datazoom_social_Stata/main/docs/en/PNAD%20Continua/PNADC_Annual_Supplements_Guide_20251119.pdf"}"'
-end

--- a/datazoom_link_en.ado
+++ b/datazoom_link_en.ado
@@ -1,0 +1,8 @@
+******************************************************
+*                   datazoom_link_en.ado                  *
+******************************************************
+* version 1.0
+
+program define datazoom_link_en
+	di `"{browse "https://raw.githubusercontent.com/datazoompuc/datazoom_social_Stata/main/docs/en/PNAD%20Continua/PNADC_Annual_Supplements_Guide_20251119.pdf"}"'
+end

--- a/datazoom_social.pkg
+++ b/datazoom_social.pkg
@@ -12,6 +12,7 @@ f datazoom_social.pkg
 f datazoom_social.sthlp
 f datazoom_message.ado
 f datazoom_link.ado
+f datazoom_link_en.ado
 F dict.dta
 f read_compdct.ado
 f Censo/datazoom_censo.ado


### PR DESCRIPTION
Extract the English browse link into its own ado file (datazoom_link_en.ado) and remove the duplicate program from datazoom_link.ado. Update datazoom_social.pkg to include the new file. This separates localization concerns and keeps the Portuguese link in datazoom_link.ado while adding a dedicated English helper (version header added).

Na organização anterior, os programas que definem links para o guia de suplementos da pnad em pt-br e em inglês estavam no mesmo .ado file. No entanto, por vezes, isso gerava erro no Stata quando a função datazoom_link_en. Por isso, criei outro .ado file para definir datazoom_link_en.

Assim, alterei o datazoom_social.pkg para que esse novo file seja baixado quando um usuário fizer a instalação do pacote.