### PR TITLE
Include identification type in PNADC_Continua Trimestral help docs

### DIFF
--- a/PNAD_Continua/Trimestral/datazoom_pnadcontinua.sthlp
+++ b/PNAD_Continua/Trimestral/datazoom_pnadcontinua.sthlp
@@ -18,7 +18,7 @@
 {title:Title}
 
 {p 4 4 2}
-{cmd:datazoom_pnadcont_anual} {hline 2} Acesso aos microdados da PNAD Contínua {c -}  Divulgação Trimestral
+{cmd:datazoom_pnadcontinua} {hline 2} Acesso aos microdados da PNAD Contínua {c -}  Divulgação Trimestral
 
 {marker syntax}{...}
 {title:Syntax}
@@ -34,10 +34,10 @@
 {synopt:{opt saving(str)}} caminho da pasta onde serão salvas as novas bases de dados {p_end}
 {synopt:{opt english}} labels das variáveis em inglês {p_end}
 
-{syntab:Identificação do Indivíduo}
+{syntab:Identificação do Indivíduo (é necessário escolher uma das opções abaixo)}
 {synopt:{opt nid}} Sem identificação {p_end}
 {synopt:{opt idbas}} Identificação básica {p_end}
-{synopt:{opt idrs}} Avançada {p_end}
+{synopt:{opt idrs}} Avançada (Ribas-Soares) {p_end}
 {synoptline}
 {p2colreset}{...}
 {p 4 6 2}
@@ -48,8 +48,8 @@ Digite {cmd:db datazoom_pnadcontinua} para utilizar a função via caixa de diá
 {title:Description}
 
 {p 4 4 2}
-{cmd:datazoom_pnadcontinua} extrai e constrói bases de dados da PNAD Contínua em formato Stata a partir 
-dos microdados originais. O programa pode ser utilizado para os anos de 2012 a 2020. 
+{cmd:datazoom_pnadcontinua} extrai e gera bases de dados da PNAD Contínua em formato Stata a partir 
+dos microdados originais do IBGE, que devem ser previamente baixados. Atualmente programa pode ser utilizado para os anos de 2012 a 2025. 
 
 {p 4 4 2}
 Embora seja uma pesquisa trimestral, este programa não permite a escolha de trimestres específicos para extração, 
@@ -57,8 +57,8 @@ somente anos. O pacote gera uma base única para o ano, com os trimestres empilh
 IBGE, este programa está em constante atualização.
   
 {p 4 4 2}
-A Pnad Contínua Trimestral é uma pesquisa em painel, na qual cada domicílio é entrevistado cinco vezes, durante cinco trimestres 
-consecutivos. Apesar de identificar corretamente o mesmo domicílio nas cinco entrevistas, a Pnad Contínua não atribui o 
+A PNAD Contínua Trimestral é uma pesquisa em painel, na qual cada domicílio é entrevistado cinco vezes, durante cinco trimestres 
+consecutivos. Apesar de identificar corretamente o mesmo domicílio nas cinco entrevistas, a PNAD Contínua não atribui o 
 mesmo número de identificação a cada membro do domicílio em todas as entrevistas. Caso o usuário necessite trabalhar com um painel
 de indivíduos, é necessário construir uma variável que identifique o mesmo indivíduo ao longo das pesquisas. 
 Para isso, são utilizados os algoritmos propostos por Ribas e Soares (2008). Os autores elaboram uma identificação básica e outra
@@ -67,9 +67,8 @@ A ideia dos algoritmos é verificar inconsistências no conjunto de variáveis. 
 da capacidade computacional utilizada, o programa pode consumir um tempo razoável para realizar a identificação.
 
 {p 4 4 2}
-Se a opção {opt nid} for escolhida, uma base de dados para cada ano selecionado será gerada. Ao utilizar as outras opçãos 
-(identificadas), é necessário selecionar todos os ano. As base de dados para cada painel da PNAD Contínua será o produto final.
-Um painel da PNAD é um conjunto de domicílios que ingressam e deixam o ciclo de entrevistas no mesmo trimestre. Se for o caso,
+Se a opção {opt nid} (sem identificação) for escolhida, uma base de dados para cada ano selecionado será gerada. Ao utilizar as outras opções 
+(identificadas), é necessário selecionar todos os anos que compõem o painel de interesse. As base de dados para cada painel da PNAD Contínua que tem parte nos anos selecionados será o produto final. Um painel da PNAD é um conjunto de domicílios que ingressam e deixam o ciclo de entrevistas no mesmo trimestre. Se for o caso,
 utilize o comando {help append} para empilhar as bases.
 
 
@@ -78,8 +77,8 @@ utilize o comando {help append} para empilhar as bases.
 {dlgtab:Input}
 
 {phang} 
-{opt years(numlist)} especifica a lista de anos com os quais o usuário deseja trabalhar. Este programa 
-pode ser utilizado para o período de 2012 a 2020. Não é possível escolher trimestres específicos.
+{opt years(numlist)} especifica a lista de anos com os quais o usuário deseja trabalhar. Este programa atualmente
+pode ser utilizado para o período de 2012 a 2025. Não é possível escolher trimestres específicos.
 
 {phang} {opt original(str)} indica o caminho da pasta onde estão localizados os arquivos de dados originais. 
 Existe um arquivo de microdados para cada trimestre da pesquisa. Todos eles devem estar posicionados na mesma pasta 
@@ -87,16 +86,21 @@ para que o programa funcione adequadamente.
 
 {phang} {opt saving(str)} indica o caminho da pasta onde devem ser salvas as bases de dados produzidas pelo programa.
 
+{phang} {opt nid} Sem identificação / {opt idbas} Identificação básica / {opt idrs} Avançada (Ribas-Soares)
+
+{phang} {opt english} gera labels das variáveis em inglês (opcional)
+
+
 {marker examples}{...}
 {title:Examples}
 
 {p 4 4 2}
 Bases de dados trimestrais 
 
-{p 8 6 2}datazoom_pnadcontinua, years(2012 2013 2014) original("~/mydata") saving("~/mydata") english
+{p 8 6 2}datazoom_pnadcontinua, years(2012 2013 2014) original("~/mydata") saving("~/mydata") nid english
 
 {p 6 6 2}
-Três bases de dados são geradas, uma para cada ano selecionado.
+Três bases de dados são geradas, uma para cada ano selecionado, sem identificação de indivíduos ao longo dos painéis e com labels das variáveis em inglês.
 
 {title:Author}
 

--- a/PNAD_Continua/Trimestral/datazoom_pnadcontinua_en.sthlp
+++ b/PNAD_Continua/Trimestral/datazoom_pnadcontinua_en.sthlp
@@ -18,7 +18,7 @@
 {title:Title}
 
 {p 4 4 2}
-{cmd:datazoom_pnadcont_anual} {hline 2} Access to Continuous PNAD microdata {c -}  Quarterly Dissemination
+{cmd:datazoom_pnadcont_en} {hline 2} Access to Continuous PNAD microdata {c -}  Quarterly Dissemination
 
 {marker syntax}{...}
 {title:Syntax}
@@ -48,8 +48,8 @@ Use command {cmd:db datazoom_pnadcontinua_en} to access through dialog box.
 {title:Description}
 
 {p 4 4 2}
-{cmd:datazoom_pnadcontinua} extracts Continuous PNAD databases from the original IBGE microdata. 
-Can be used for years 2012 to 2020. 
+{cmd:datazoom_pnadcontinua} extracts Continuous PNAD databases from the original IBGE microdata, which must be downloaded beforehand. 
+Currently supports data from years 2012 to 2025. 
 
 {p 4 4 2}
 Although Continuous PNAD is a quartely survey, this program does not allow specific quarter to be chosen, only years. The package generates a single database for each year, with quarters appended. 
@@ -57,7 +57,7 @@ As Continuous PNAD is still published by IBGE, this program is
 under constant update.
   
 {p 4 4 2}
-The Continuous PNAD is a panel survey, in which each household is interviewed for five consecutive quarters. Despite correctly identifying the same household in all five interviews, the Pnad Continuous does not assign the same identification number to each member of the household at every interview. 
+The Continuous PNAD is a panel survey, in which each household is interviewed for five consecutive quarters. Despite correctly identifying the same household in all five interviews, the PNAD Continuous does not assign the same identification number to each member of the household at every interview. 
 In case the user wishes to work with an individuals panel,
 it is necessary to construct a variable to identify each individual throughout different surveys.
  For this reason we use algorithms suggested by Ribas and Soares (2008).
@@ -68,10 +68,10 @@ amount of time to perform the identification process, depending on the computati
 capacity.
 
 {p 4 4 2}
-If {opt nid} is selected, the program will generate a database for each selected year. Other options
+If {opt nid} is selected (no identification), the program will generate a database for each selected year. Other options
  will yield one database for each PME panel. That is,
 the program will generate a database for each set of households with partook the survey cycle in a given 
-quarter. If so desired, use command {help append} to pool together databases.
+quarter. Therefore, it is recommended that you select all years included in the panels of interest. If desired, use command {help append} to pool the databases together.
 
 
 {marker options}{...}
@@ -79,8 +79,8 @@ quarter. If so desired, use command {help append} to pool together databases.
 {dlgtab:Input}
 
 {phang} 
-{opt years(numlist)} specifies the list of years the user wants to work with. This program
-covers all years from 2012 to 2020. It is not possible to choose specific quarters.
+{opt years(numlist)} specifies the list of years the user wants to work with. This program currently
+covers all years from 2012 to 2025. It is not possible to choose specific quarters.
 
 {phang} {opt original(str)} indicates the path of the original data files. 
 There is one data file for each quarter. All of these files must be placed in the same 
@@ -88,16 +88,21 @@ folder for the program's proper functioning.
 
 {phang} {opt saving(str)} specifies the folder path where the new databases are to be saved.
 
+{phang} {opt nid} No Identification / {opt idbas} Basic Identification / {opt idrs} Advanced Identification (Ribas-Soares)
+
+{phang} {opt english} generates variable labels in english (optional)
+
+
 {marker examples}{...}
 {title:Examples}
 
 {p 4 4 2}
 Quarterly databases, with English variable labels
 
-{p 8 6 2}datazoom_pnadcontinua, years(2012 2013 2014) original("~/mydata") saving("~/mydata") english
+{p 8 6 2}datazoom_pnadcontinua, years(2012 2013 2014) original("~/mydata") saving("~/mydata") nid english
 
 {p 6 6 2}
-Three databases are created, one for each year.
+Three databases are created, one for each year, with no identification of individuals throughout the panels.
 
 {title:Author}
 


### PR DESCRIPTION
Edit Portuguese and English .sthlp files for datazoom_pnadcontinua (Trimestral): use command identifiers in examples, clarify identification options (nid / idbas / idrs (Ribas-Soares)), and add note about optional English variable labels. Update supported years from 2012–2020 to 2012–2025 and clarify that original IBGE microdata must be downloaded beforehand. Improve descriptions and examples (include nid and english flags), and add guidance on selecting full panels and using append when needed.

Contributes to clarify the problem described on issue #180 