### PR TITLE
Fix buttons dlgbox pnadc & update function to read 2026 pnadc quarter files

### DIFF
--- a/PNAD/datazoom_pnad.sthlp
+++ b/PNAD/datazoom_pnad.sthlp
@@ -56,7 +56,7 @@ Digite {cmd:db datazoom_pnad} para utilizar a função via caixa de diálogo.
 
 {p 4 4 2}
 {cmd:datazoom_pnad} extrai e constrói bases de dados da PNAD em formato Stata (.dta) a partir dos microdados originais do IBGE. 
-O programa pode ser utilizado para todos anos desde 1981 (exceto os anos censitários e 1994).
+O programa pode ser utilizado para todos anos desde 1981 até 2015 (exceto os anos censitários e 1994).
 
 {p 4 4 2}
 Existe a opção de compatibilizar variáveis ao longo dos anos. Isso é feito para as variáveis mais frequentes na PNAD, ou seja, 

--- a/PNAD_Continua/Trimestral/datazoom_pnadcontinua.dlg
+++ b/PNAD_Continua/Trimestral/datazoom_pnadcontinua.dlg
@@ -15,13 +15,14 @@ BEGIN
    CHECKBOX    ck2016 @ +24 50 20, label("2016")  option(2016)
    CHECKBOX    ck2017 @ +24 50 20, label("2017")  option(2017)
    CHECKBOX    ck2018 @ +24 50 20, label("2018")  option(2018)
-   CHECKBOX    ck2019 +55 -144 50 20, label("2019")  option(2019)
-   CHECKBOX    ck2020 @ +24 50 20, label("2020")  option(2020)
+   CHECKBOX    ck2019 @ +24 50 20, label("2019")  option(2019)
+   CHECKBOX    ck2020 +55 -144 50 20, label("2020")  option(2020)
    CHECKBOX    ck2021 @ +24 50 20, label("2021")  option(2021)
    CHECKBOX    ck2022 @ +24 50 20, label("2022")  option(2022)
    CHECKBOX    ck2023 @ +24 50 20, label("2023")  option(2023)
    CHECKBOX    ck2024 @ +24 50 20, label("2024")  option(2024)
    CHECKBOX    ck2025 @ +24 50 20, label("2025")  option(2025)
+   CHECKBOX    ck2026 @ +24 50 20, label("2026")  option(2026)
    
    GROUPBOX caixaDicionarios 160 10 140 118, label("Bases de Dados")
 
@@ -72,14 +73,14 @@ BEGIN
    beginoptions
       /*Parte da syntax: anos a extrair*/
       put "years("
-      option main.ck2012 main.ck2013 main.ck2014 main.ck2015 main.ck2016 main.ck2017 main.ck2018 main.ck2019 main.ck2020 main.ck2021 main.ck2022 main.ck2023 main.ck2024 main.ck2025
+      option main.ck2012 main.ck2013 main.ck2014 main.ck2015 main.ck2016 main.ck2017 main.ck2018 main.ck2019 main.ck2020 main.ck2021 main.ck2022 main.ck2023 main.ck2024 main.ck2025 main.ck2026
       put ") "
       /*Parte da syntax: base de dados originais*/
       put saidadata " "
       put saidasalvando
 
       /* Correção da sintaxe de mapeamento dos botões de rádio */
-      option radio(main.nid main.idbas main.idrs)
+      option radio(main nid idbas idrs)
       option main.eng
    endoptions
    stata

--- a/PNAD_Continua/Trimestral/datazoom_pnadcontinua.dlg
+++ b/PNAD_Continua/Trimestral/datazoom_pnadcontinua.dlg
@@ -6,7 +6,7 @@ POSITION . . 340 320
 DIALOG main, label("PNAD Contínua") tabtitle("Main")
 BEGIN
 
-   GROUPBOX caixaAnos 20 10 130 200, label("Ano(s)")
+   GROUPBOX caixaAnos 20 10 130 220, label("Ano(s)")
 
    CHECKBOX    ck2012 +14 +24 50 20, label("2012")  option(2012)
    CHECKBOX    ck2013 @ +24 50 20, label("2013")  option(2013)
@@ -16,7 +16,7 @@ BEGIN
    CHECKBOX    ck2017 @ +24 50 20, label("2017")  option(2017)
    CHECKBOX    ck2018 @ +24 50 20, label("2018")  option(2018)
    CHECKBOX    ck2019 @ +24 50 20, label("2019")  option(2019)
-   CHECKBOX    ck2020 +55 -144 50 20, label("2020")  option(2020)
+   CHECKBOX    ck2020 +55 -168 50 20, label("2020")  option(2020)
    CHECKBOX    ck2021 @ +24 50 20, label("2021")  option(2021)
    CHECKBOX    ck2022 @ +24 50 20, label("2022")  option(2022)
    CHECKBOX    ck2023 @ +24 50 20, label("2023")  option(2023)

--- a/PNAD_Continua/Trimestral/datazoom_pnadcontinua.sthlp
+++ b/PNAD_Continua/Trimestral/datazoom_pnadcontinua.sthlp
@@ -55,6 +55,8 @@ dos microdados originais do IBGE, que devem ser previamente baixados. Atualmente
 Embora seja uma pesquisa trimestral, este programa não permite a escolha de trimestres específicos para extração, 
 somente anos. O pacote gera uma base única para o ano, com os trimestres empilhados. Como a pesquisa ainda é publicada pelo
 IBGE, este programa está em constante atualização.
+É possível fazer a leitura isolada de alguns trimestres em sequência. No entanto, para ler uma base é necessário ter lido as anteriores daquele mesmo ano.
+Ex: É possível ler apenas o primeiro trimestre de 2025, mas se quiser ler o terceiro trimestre é preciso ter lido o primeiro e o segundo semestre de 2025.
   
 {p 4 4 2}
 A PNAD Contínua Trimestral é uma pesquisa em painel, na qual cada domicílio é entrevistado cinco vezes, durante cinco trimestres 
@@ -78,7 +80,7 @@ utilize o comando {help append} para empilhar as bases.
 
 {phang} 
 {opt years(numlist)} especifica a lista de anos com os quais o usuário deseja trabalhar. Este programa atualmente
-pode ser utilizado para o período de 2012 a 2025. Não é possível escolher trimestres específicos.
+pode ser utilizado para o período de 2012 a 2026. Não é possível escolher trimestres específicos.
 
 {phang} {opt original(str)} indica o caminho da pasta onde estão localizados os arquivos de dados originais. 
 Existe um arquivo de microdados para cada trimestre da pesquisa. Todos eles devem estar posicionados na mesma pasta 

--- a/PNAD_Continua/Trimestral/datazoom_pnadcontinua.sthlp
+++ b/PNAD_Continua/Trimestral/datazoom_pnadcontinua.sthlp
@@ -49,7 +49,7 @@ Digite {cmd:db datazoom_pnadcontinua} para utilizar a função via caixa de diá
 
 {p 4 4 2}
 {cmd:datazoom_pnadcontinua} extrai e gera bases de dados da PNAD Contínua em formato Stata a partir 
-dos microdados originais do IBGE, que devem ser previamente baixados. Atualmente programa pode ser utilizado para os anos de 2012 a 2025. 
+dos microdados originais do IBGE, que devem ser previamente baixados. Atualmente programa pode ser utilizado para os anos de 2012 a 2026. 
 
 {p 4 4 2}
 Embora seja uma pesquisa trimestral, este programa não permite a escolha de trimestres específicos para extração, 

--- a/PNAD_Continua/Trimestral/datazoom_pnadcontinua_en.dlg
+++ b/PNAD_Continua/Trimestral/datazoom_pnadcontinua_en.dlg
@@ -15,13 +15,14 @@ BEGIN
    CHECKBOX    ck2016 @ +24 50 20, label("2016")  option(2016)
    CHECKBOX    ck2017 @ +24 50 20, label("2017")  option(2017)
    CHECKBOX    ck2018 @ +24 50 20, label("2018")  option(2018)
-   CHECKBOX    ck2019 +55 -144 50 20, label("2019")  option(2019)
-   CHECKBOX    ck2020 @ +24 50 20, label("2020")  option(2020)
+   CHECKBOX    ck2019 @ +24 50 20, label("2019")  option(2019)
+   CHECKBOX    ck2020 +55 -168 50 20, label("2020")  option(2020)
    CHECKBOX    ck2021 @ +24 50 20, label("2021")  option(2021)
    CHECKBOX    ck2022 @ +24 50 20, label("2022")  option(2022)
    CHECKBOX    ck2023 @ +24 50 20, label("2023")  option(2023)
    CHECKBOX    ck2024 @ +24 50 20, label("2024")  option(2024)
    CHECKBOX    ck2025 @ +24 50 20, label("2025")  option(2025)
+   CHECKBOX    ck2026 @ +24 50 20, label("2026")  option(2026)
    
    GROUPBOX caixaDicionarios 160 10 140 118, label("Databases")
 
@@ -71,13 +72,13 @@ BEGIN
    put "datazoom_pnadcontinua "
    beginoptions
       put "years("
-      option main.ck2012 main.ck2013 main.ck2014 main.ck2015 main.ck2016 main.ck2017 main.ck2018 main.ck2019 main.ck2020 main.ck2021 main.ck2022 main.ck2023 main.ck2024 main.ck2025
+      option main.ck2012 main.ck2013 main.ck2014 main.ck2015 main.ck2016 main.ck2017 main.ck2018 main.ck2019 main.ck2020 main.ck2021 main.ck2022 main.ck2023 main.ck2024 main.ck2025 main.ck2026
       put ") "
       put saidadata " "
       put saidasalvando
 
       /* Correção da sintaxe de mapeamento dos botões de rádio */
-      option radio(main.nid main.idbas main.idrs)
+      option radio(main nid idbas idrs)
       option main.eng
    endoptions
    stata

--- a/PNAD_Continua/Trimestral/datazoom_pnadcontinua_en.dlg
+++ b/PNAD_Continua/Trimestral/datazoom_pnadcontinua_en.dlg
@@ -6,7 +6,7 @@ POSITION . . 340 320
 DIALOG main, label("PNAD Contínua") tabtitle("Main")
 BEGIN
 
-   GROUPBOX caixaAnos 20 10 130 200, label("Year(s)")
+   GROUPBOX caixaAnos 20 10 130 220, label("Year(s)")
 
    CHECKBOX    ck2012 +14 +24 50 20, label("2012")  option(2012)
    CHECKBOX    ck2013 @ +24 50 20, label("2013")  option(2013)
@@ -56,14 +56,14 @@ RESET res1
 SCRIPT dados
 BEGIN
    create CHILD datazoom_datafolder AS pnad_data
-   pnad_data.settitle "Annual Continuous PNAD original data file"
+   pnad_data.settitle "Continuous PNAD original data file"
    pnad_data.setExitString saidadata
 END
 
 SCRIPT salvando
 BEGIN
    create CHILD datazoom_finalfolder AS pnad_dic
-   pnad_dic.settitle "Annual Continuous PNAD final data folder"
+   pnad_dic.settitle "Continuous PNAD final data folder"
    pnad_dic.setExitString saidasalvando
 END
 

--- a/PNAD_Continua/Trimestral/datazoom_pnadcontinua_en.sthlp
+++ b/PNAD_Continua/Trimestral/datazoom_pnadcontinua_en.sthlp
@@ -49,12 +49,13 @@ Use command {cmd:db datazoom_pnadcontinua_en} to access through dialog box.
 
 {p 4 4 2}
 {cmd:datazoom_pnadcontinua} extracts Continuous PNAD databases from the original IBGE microdata, which must be downloaded beforehand. 
-Currently supports data from years 2012 to 2025. 
+Currently supports data from years 2012 to 2026. 
 
 {p 4 4 2}
 Although Continuous PNAD is a quartely survey, this program does not allow specific quarter to be chosen, only years. The package generates a single database for each year, with quarters appended. 
-As Continuous PNAD is still published by IBGE, this program is
-under constant update.
+As Continuous PNAD is still published by IBGE, this program is under constant update.
+It is possible to read only some consecutive quarters. However, in order to read a given dataset, the previous quarters from the same year must have been read first.
+Example: It is possible to read only the first quarter of 2025. However, if you want to read the third quarter, you must have read both the first and second quarters of 2025.
   
 {p 4 4 2}
 The Continuous PNAD is a panel survey, in which each household is interviewed for five consecutive quarters. Despite correctly identifying the same household in all five interviews, the PNAD Continuous does not assign the same identification number to each member of the household at every interview. 

--- a/PNAD_Continua/Trimestral/datazoom_pnadcontinua_en.sthlp
+++ b/PNAD_Continua/Trimestral/datazoom_pnadcontinua_en.sthlp
@@ -81,7 +81,7 @@ quarter. Therefore, it is recommended that you select all years included in the 
 
 {phang} 
 {opt years(numlist)} specifies the list of years the user wants to work with. This program currently
-covers all years from 2012 to 2025. It is not possible to choose specific quarters.
+covers all years from 2012 to 2026. It is not possible to choose specific quarters.
 
 {phang} {opt original(str)} indicates the path of the original data files. 
 There is one data file for each quarter. All of these files must be placed in the same 

--- a/datazoom_social.dlg
+++ b/datazoom_social.dlg
@@ -32,9 +32,9 @@ BEGIN
 	TEXTBOX txb_censo    		15 75 140 40, label("Censo Demográfico - 1970 a 2010") center
 	TEXTBOX txb_ecinf    		+158 @ @ @, label("Economia Informal Urbana - 1997 e 2003") center
 	TEXTBOX txb_pme    	 	+158 @ @ @, label("Pesquisa Mensal de Emprego - 1990 a 2015") center
-	TEXTBOX txb_pnad     		+158 @ @ @, label("PNAD Antiga - 2001 a 2015") center
+	TEXTBOX txb_pnad     		+158 @ @ @, label("PNAD Antiga - 1981 a 2015") center
 	
-    	TEXTBOX txb_pncon			15 175 140 40, label("PNAD Contínua - 2012 a 2025") center
+    	TEXTBOX txb_pncon			15 175 140 40, label("PNAD Contínua - 2012 a 2026") center
 	TEXTBOX txb_pncov			+158 @ @ @, label("PNAD Covid - 2020") center
 	TEXTBOX txb_pns   			+158 @ @ @, label("Pesquisa Nacional de Saúde - 2013 e 2019") center
 	TEXTBOX txb_pof 			+158 @ @ @, label("Pesquisa de Orçamentos Familiares - 1995 a 2018") center

--- a/datazoom_social_en.dlg
+++ b/datazoom_social_en.dlg
@@ -32,9 +32,9 @@ BEGIN
 	TEXTBOX txb_censo    		15 75 140 45, label("Census - 1970 to 2010") center
 	TEXTBOX txb_ecinf    		+158 @ @ @, label("Urban Informal Economy - 1997 and 2003") center
 	TEXTBOX txb_pme    	 	+158 @ @ @, label("Monthly Employment Survey - 1990 to 2015") center
-	TEXTBOX txb_pnad     		+158 @ @ @, label("National Household Sample Survey - 2001 to 2015") center
+	TEXTBOX txb_pnad     		+158 @ @ @, label("National Household Sample Survey - 1981 to 2015") center
 	
-    	TEXTBOX txb_pncon			15 180 140 40, label("Continuous PNAD - 2012 to 2025") center
+    	TEXTBOX txb_pncon			15 180 140 40, label("Continuous PNAD - 2012 to 2026") center
 	TEXTBOX txb_pncov			+158 @ @ @, label("PNAD Covid - 2020") center
 	TEXTBOX txb_pns   			+158 @ @ @, label("National Survey of Health - 2013 and 2019") center
 	TEXTBOX txb_pof 			+158 @ @ @, label("Consumer Expenditure Survey - 1995 to 2018") center


### PR DESCRIPTION
Ajusta os botões da caixa de diálogo da PNADC trimestral e atualiza a função para ler também o ano de 2026.

Faz as mudanças necessárias nos help files, e outras dlg boxes (em pt e en)

Closes #192 and #191 .